### PR TITLE
Write from PHP engine to Go context directly, using an exported callback.

### DIFF
--- a/lib/engine/php/context.c
+++ b/lib/engine/php/context.c
@@ -12,7 +12,7 @@
 #include "engine.h"
 #include "context.h"
 
-engine_context *context_new(php_engine *engine) {
+engine_context *context_new(php_engine *engine, void *parent) {
 	engine_context *context;
 
 	#ifdef ZTS
@@ -25,23 +25,14 @@ engine_context *context_new(php_engine *engine) {
 		return_multi(NULL, 1);
 	}
 
-	// Allocate internal buffer.
-	context->buffer.bytes = (char *) calloc(BUFFER_SIZE, sizeof(char));
-	if (context->buffer.bytes == NULL) {
-		free(context);
-		return_multi(NULL, 1);
-	}
-
-	context->buffer.size = BUFFER_SIZE;
-	context->buffer.used = 0;
 	context->engine = engine;
+	context->parent = parent;
 
 	SG(server_context) = (void *) context;
 
 	// Initialize request lifecycle.
 	if (php_request_startup(TSRMLS_C) == FAILURE) {
 		SG(server_context) = NULL;
-		free(context->buffer.bytes);
 		free(context);
 
 		return_multi(NULL, 1);
@@ -70,30 +61,9 @@ void context_run(engine_context *context, char *filename) {
 	return_multi(NULL, 0);
 }
 
-size_t context_sync(engine_context *context, char **buffer) {
-	// Return zero bytes synched if context buffer is empty.
-	if (context->buffer.used == 0) {
-		return_multi(0, 0);
-	}
-
-	*buffer = (char *) malloc(context->buffer.used);
-	if (*buffer == NULL) {
-		return_multi(0, 1);
-	}
-
-	size_t num = context->buffer.used;
-	memcpy(*buffer, context->buffer.bytes, context->buffer.used);
-
-	context->buffer.bytes[0] = '\0';
-	context->buffer.used = 0;
-
-	return_multi(num, 0);
-}
-
 void context_destroy(engine_context *context) {
 	php_request_shutdown((void *) 0);
 
 	SG(server_context) = NULL;
-	free(context->buffer.bytes);
 	free(context);
 }

--- a/lib/engine/php/context.h
+++ b/lib/engine/php/context.h
@@ -5,16 +5,11 @@
 
 typedef struct _engine_context {
 	php_engine *engine; // Parent engine instance.
-	struct {
-		char *bytes;
-		size_t size;
-		size_t used;
-	} buffer;
+	void *parent;       // Pointer to parent Go context, used for passing to callbacks.
 } engine_context;
 
-engine_context *context_new(php_engine *engine);
+engine_context *context_new(php_engine *engine, void *parent);
 void context_run(engine_context *context, char *filename);
-size_t context_sync(engine_context *context, char **buffer);
 void context_destroy(engine_context *context);
 
 #endif

--- a/lib/engine/php/engine.go
+++ b/lib/engine/php/engine.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"unsafe"
 
 	// Internal packages
 	"github.com/deuill/sigil/lib/engine"
@@ -24,15 +25,14 @@ type Engine struct {
 }
 
 func (e *Engine) NewContext(w io.Writer) (engine.Context, error) {
-	ptr, err := C.context_new(e.engine)
+	ctx := &Context{writer: w}
+
+	ptr, err := C.context_new(e.engine, unsafe.Pointer(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize context for PHP engine")
 	}
 
-	ctx := &Context{
-		context: ptr,
-		writer:  w,
-	}
+	ctx.context = ptr
 
 	runtime.SetFinalizer(ctx, func(ctx *Context) {
 		C.context_destroy(ctx.context)


### PR DESCRIPTION
Previously, the PHP engine would write to a temporary buffer which was periodically synched on the Go side. This caused various issues (access contention, delayed sync etc) which were resolved by having PHP write to the Go context directly, via an exported function.

This requires us passing a pointer to the parent Go `php.Context` structure, including the `io.Writer` embedded within, to the C context, which is then passed back to Go for use as a function parameter in a declared callback.
